### PR TITLE
various improvements and bugfixes

### DIFF
--- a/bitslice_test.go
+++ b/bitslice_test.go
@@ -18,17 +18,21 @@ func TestBitslice(t *testing.T) {
 		output  []byte
 		numBits int
 		level   int
+		index   uint32
 	}{
-		{data, []byte{0x8c, 0xee}, 16, 1},
-		{data, []byte{0xa6}, 8, 1},
-		{data, []byte{0x0a}, 4, 2},
-		{data, []byte{0x00, 0xe3}, 9, 3},
+		{data, []byte{0x8c, 0xee}, 16, 1, uint32(0x8cee)},
+		{data, []byte{0xa6}, 8, 1, uint32(0xa6)},
+		{data, []byte{0x0a}, 4, 2, uint32(0x0a)},
+		{data, []byte{0x00, 0xe3}, 9, 3, uint32(0xe3)},
 	}
 
 	for i, v := range testVectors {
-		computed := bitslice(v.input, v.numBits, v.level)
+		computed, index := bitslice(v.input, v.numBits, v.level)
 		if !bytes.Equal(v.output, computed) {
 			t.Fatalf("failure in vector %d: got %v; wanted %v", i, computed, v.output)
+		}
+		if index != v.index {
+			t.Fatalf("wrong index: %d != %d", index, v.index)
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -16,7 +16,7 @@ type Hasher interface {
 type ValueConstructor interface {
 	// Construct a new template empty value for the leaf, so that the
 	// Unmarshalling routine has the correct type template.
- 	Construct() interface{}
+	Construct() interface{}
 }
 
 // Config defines the shape of the MerkleTree.
@@ -52,11 +52,16 @@ func log2(y ChildIndex) ChildIndex {
 // and `n`, the maximum number of entries in a leaf before a
 // new level of the tree is introduced.
 func NewConfig(h Hasher, m ChildIndex, n ChildIndex, v ValueConstructor) Config {
-	return Config{hasher: h, m: m, n: n, c: log2(m), v : v}
+	return Config{hasher: h, m: m, n: n, c: log2(m), v: v}
 }
 
+func (c Config) prefixAndIndexAtLevel(level Level, h Hash) (Prefix, ChildIndex) {
+	prfx, ci := bitslice(h, int(c.c), int(level))
+	return Prefix(prfx), ChildIndex(ci)
+}
 func (c Config) prefixAtLevel(level Level, h Hash) Prefix {
-	return Prefix(bitslice(h, int(c.c), int(level)))
+	ret, _ := c.prefixAndIndexAtLevel(level, h)
+	return ret
 }
 
 func div8roundUp(i ChildIndex) ChildIndex {

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,7 @@
 package merkleTree
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -32,3 +33,6 @@ type BadChildPointerError struct {
 func (b BadChildPointerError) Error() string {
 	return fmt.Sprintf("Wanted a Hash; got type %T instead", b.V)
 }
+
+// ErrBadINode is thrown when we find a corrupt/malformed iNode
+var ErrBadINode = errors.New("Bad iNode found")

--- a/inode.go
+++ b/inode.go
@@ -1,0 +1,48 @@
+package merkleTree
+
+import ()
+
+type childPointerMap struct {
+	tab []Hash
+}
+
+func newChildPointerMap(capacity ChildIndex) *childPointerMap {
+	return &childPointerMap{
+		tab: make([]Hash, capacity),
+	}
+}
+
+func newChildPointerMapFromNode(n *Node) *childPointerMap {
+	return &childPointerMap{
+		tab: n.INodes,
+	}
+}
+
+func (c *childPointerMap) exportToNode(h Hasher, prevRoot Hash, level Level) (hash Hash, node Node, objExported []byte, err error) {
+	node.Type = nodeTypeINode
+	node.INodes = c.tab
+	return node.export(h, prevRoot, level)
+}
+
+func (n Node) export(h Hasher, prevRoot Hash, level Level) (hash Hash, node Node, objExported []byte, err error) {
+	if prevRoot != nil && level == Level(0) {
+		n.PrevRoot = prevRoot
+	}
+	objExported, err = encodeToBytes(n)
+	if err == nil {
+		hash = h.Hash(objExported)
+	}
+	return hash, n, objExported, err
+}
+
+func (n *Node) findChildByIndex(i ChildIndex) (Hash, error) {
+	if n.INodes == nil || int(i) >= len(n.INodes) {
+		return nil, ErrBadINode
+	}
+	return n.INodes[i], nil
+}
+
+func (c *childPointerMap) set(i ChildIndex, h Hash) *childPointerMap {
+	c.tab[i] = h
+	return c
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -3,8 +3,8 @@ package merkleTree
 // StorageEngine specifies how to store and lookup merkle tree nodes
 // and roots.  You can use a DB like Dynamo or SQL to do this.
 type StorageEngine interface {
-	StoreNode(Hash, Node, []byte) error
+	StoreNode(Hash, []byte) error
 	CommitRoot(prev Hash, curr Hash, txinfo TxInfo) error
-	LookupNode(Hash) (*Node, error)
+	LookupNode(Hash) []byte
 	LookupRoot() (Hash, error)
 }

--- a/mem.go
+++ b/mem.go
@@ -8,13 +8,13 @@ import (
 // MemEngine is an in-memory MerkleTree engine, used now mainly for testing
 type MemEngine struct {
 	root  Hash
-	nodes map[string](*Node)
+	nodes map[string][]byte
 }
 
 // NewMemEngine makes an in-memory storage engine, mainly for testing.
 func NewMemEngine() *MemEngine {
 	return &MemEngine{
-		nodes: make(map[string](*Node)),
+		nodes: make(map[string][]byte),
 	}
 }
 
@@ -33,9 +33,8 @@ func (m *MemEngine) Hash(d []byte) Hash {
 }
 
 // LookupNode looks up a MerkleTree node by hash
-func (m *MemEngine) LookupNode(h Hash) (*Node, error) {
-	ret := m.nodes[hex.EncodeToString(h)]
-	return ret, nil
+func (m *MemEngine) LookupNode(h Hash) (b []byte) {
+	return m.nodes[hex.EncodeToString(h)]
 }
 
 // LookupRoot fetches the root of the in-memory tree back out
@@ -44,7 +43,7 @@ func (m *MemEngine) LookupRoot() (Hash, error) {
 }
 
 // StoreNode stores the given node under the given key.
-func (m *MemEngine) StoreNode(key Hash, val Node, _ []byte) error {
-	m.nodes[hex.EncodeToString(key)] = &val
+func (m *MemEngine) StoreNode(key Hash, b []byte) error {
+	m.nodes[hex.EncodeToString(key)] = b
 	return nil
 }

--- a/obj_factory_test.go
+++ b/obj_factory_test.go
@@ -17,8 +17,10 @@ func genBinary(l int) []byte {
 }
 
 type testValue struct {
-	seqno int
-	key   string
+	_struct bool `codec:",toarray"`
+	Seqno   int
+	Key     string
+	KeyRaw  []byte
 }
 
 // TestObjFactory generates a bunch of test objects for debugging
@@ -46,7 +48,7 @@ func (of TestObjFactory) dumpAll() []KeyValuePair {
 func (of *TestObjFactory) Produce() KeyValuePair {
 	key := genBinary(8)
 	keyString := hex.EncodeToString(key)
-	val := testValue{seqno: of.seqno, key: keyString}
+	val := testValue{Seqno: of.seqno, Key: keyString, KeyRaw: key}
 	of.seqno++
 	kvp := KeyValuePair{Key: key, Value: val}
 	of.objs[keyString] = kvp
@@ -70,8 +72,8 @@ func (of *TestObjFactory) modifySome(mod int) {
 			panic(fmt.Sprintf("Got value of wrong type: %T", v))
 		}
 		if (i % mod) == 0 {
-			tv.seqno *= 2
-			tv.key += "-yo-dawg"
+			tv.Seqno *= 2
+			tv.Key += "-yo-dawg"
 		}
 		i++
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -4,32 +4,46 @@ import (
 	"testing"
 )
 
-func makeTestConfig(of *TestObjFactory) Config {
-	return NewConfig(SHA512Hasher{}, 4, 16, of)
+func makeTestConfig(of *TestObjFactory, m ChildIndex, n ChildIndex) Config {
+	return NewConfig(SHA512Hasher{}, m, n, of)
 }
 
-func newTestMemTree(of *TestObjFactory) (t *Tree, m *MemEngine) {
-	m = NewMemEngine()
-	t = NewTree(m, makeTestConfig(of))
-	return t, m
+func newTestMemTree(of *TestObjFactory, m ChildIndex, n ChildIndex) (t *Tree, me *MemEngine) {
+	me = NewMemEngine()
+	t = NewTree(me, makeTestConfig(of, m, n))
+	return t, me
 }
 
-func testSimpleBuild(t *testing.T) {
+func testSimpleBuild(t *testing.T, numElem int, m ChildIndex, n ChildIndex) {
 	of := NewTestObjFactory()
-	objs := of.Mproduce(1024)
+	objs := of.Mproduce(numElem)
 	sm := NewSortedMapFromList(objs)
-	tree, _ := newTestMemTree(of)
+	tree, _ := newTestMemTree(of, m, n)
 	if err := tree.Build(sm, nil); err != nil {
 		t.Fatalf("Error in build: %v", err)
 	}
 	findAll(t, tree, objs)
 }
 
-// This example shows how to build the tree.
-func TestSimpleBuild(t *testing.T) {
-	for i := 0; i < 32; i++ {
-		testSimpleBuild(t)
+func TestSimpleBuild4by16(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		testSimpleBuild(t, 1024, ChildIndex(4), ChildIndex(16))
 	}
+}
+
+func TestSimpleBuild2by4(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		testSimpleBuild(t, 1024, ChildIndex(2), ChildIndex(4))
+	}
+}
+
+func TestSimpleBuild256by256(t *testing.T) {
+	for i := 0; i < 2; i++ {
+		testSimpleBuild(t, 8192, ChildIndex(256), ChildIndex(256))
+	}
+}
+func TestSimpleBuildSmall(t *testing.T) {
+	testSimpleBuild(t, 1, ChildIndex(2), ChildIndex(2))
 }
 
 func findAll(t *testing.T, tree *Tree, objs []KeyValuePair) {

--- a/types.go
+++ b/types.go
@@ -19,8 +19,8 @@ type Prefix []byte
 // hash from the one used for interior nodes.
 type KeyValuePair struct {
 	_struct bool        `codec:",toarray"`
-	Key     Hash        `codec:"key"`
-	Value   interface{} `codec:"value"`
+	Key     Hash        `codec:"k"`
+	Value   interface{} `codec:"v"`
 }
 
 type nodeType int
@@ -34,9 +34,10 @@ const (
 // Node is a node in the merkle tree. Can be either an interior iNode or
 // a leaf that has pointers to user data.
 type Node struct {
-	PrevRoot Hash           `codec:"prev_root,omitempty"`
-	Tab      []KeyValuePair `codec:"tab"`
-	Type     nodeType       `codec:"type"`
+	PrevRoot Hash           `codec:"p,omitempty"`
+	INodes   []Hash         `codec:"i,omitempty"`
+	Leafs    []KeyValuePair `codec:"l,omitempty"`
+	Type     nodeType       `codec:"t"`
 }
 
 // Level specifies what level of the merkle tree we are at.


### PR DESCRIPTION
- simplify the storage engine, so that msgpack/unpack is factored out; now just deals in bytes
- fix actual storage of values in leafs (which was broken before)
- shorten the key names for space-savings
- use different structures for nodes and leafs (dense v sparse)
- index node pointers by index, and not by prefix