### PR TITLE
add context

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,8 @@
 package merkleTree_test
 
 import (
+	"golang.org/x/net/context"
+
 	merkleTree "github.com/keybase/go-merkle-tree"
 )
 
@@ -38,5 +40,5 @@ func ExampleTree_Build() {
 	var txInfo merkleTree.TxInfo
 
 	// Build the tree
-	tree.Build(sm, txInfo)
+	tree.Build(context.TODO(), sm, txInfo)
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,10 +1,12 @@
 package merkleTree
 
+import "golang.org/x/net/context"
+
 // StorageEngine specifies how to store and lookup merkle tree nodes
 // and roots.  You can use a DB like Dynamo or SQL to do this.
 type StorageEngine interface {
-	StoreNode(Hash, []byte) error
-	CommitRoot(prev Hash, curr Hash, txinfo TxInfo) error
-	LookupNode(Hash) ([]byte, error)
-	LookupRoot() (Hash, error)
+	StoreNode(context.Context, Hash, []byte) error
+	CommitRoot(ctx context.Context, prev Hash, curr Hash, txinfo TxInfo) error
+	LookupNode(context.Context, Hash) ([]byte, error)
+	LookupRoot(context.Context) (Hash, error)
 }

--- a/mem.go
+++ b/mem.go
@@ -3,6 +3,8 @@ package merkleTree
 import (
 	"crypto/sha512"
 	"encoding/hex"
+
+	"golang.org/x/net/context"
 )
 
 // MemEngine is an in-memory MerkleTree engine, used now mainly for testing
@@ -21,29 +23,29 @@ func NewMemEngine() *MemEngine {
 var _ StorageEngine = (*MemEngine)(nil)
 
 // CommitRoot "commits" the root ot the blessed memory slot
-func (m *MemEngine) CommitRoot(prev Hash, curr Hash, txinfo TxInfo) error {
+func (m *MemEngine) CommitRoot(_ context.Context, prev Hash, curr Hash, txinfo TxInfo) error {
 	m.root = curr
 	return nil
 }
 
 // Hash runs SHA512
-func (m *MemEngine) Hash(d []byte) Hash {
+func (m *MemEngine) Hash(_ context.Context, d []byte) Hash {
 	sum := sha512.Sum512(d)
 	return Hash(sum[:])
 }
 
 // LookupNode looks up a MerkleTree node by hash
-func (m *MemEngine) LookupNode(h Hash) (b []byte, err error) {
+func (m *MemEngine) LookupNode(_ context.Context, h Hash) (b []byte, err error) {
 	return m.nodes[hex.EncodeToString(h)], nil
 }
 
 // LookupRoot fetches the root of the in-memory tree back out
-func (m *MemEngine) LookupRoot() (Hash, error) {
+func (m *MemEngine) LookupRoot(_ context.Context) (Hash, error) {
 	return m.root, nil
 }
 
 // StoreNode stores the given node under the given key.
-func (m *MemEngine) StoreNode(key Hash, b []byte) error {
+func (m *MemEngine) StoreNode(_ context.Context, key Hash, b []byte) error {
 	m.nodes[hex.EncodeToString(key)] = b
 	return nil
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -2,6 +2,8 @@ package merkleTree
 
 import (
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func makeTestConfig(of *TestObjFactory, m ChildIndex, n ChildIndex) Config {
@@ -19,7 +21,7 @@ func testSimpleBuild(t *testing.T, numElem int, m ChildIndex, n ChildIndex) {
 	objs := of.Mproduce(numElem)
 	sm := NewSortedMapFromList(objs)
 	tree, _ := newTestMemTree(of, m, n)
-	if err := tree.Build(sm, nil); err != nil {
+	if err := tree.Build(context.TODO(), sm, nil); err != nil {
 		t.Fatalf("Error in build: %v", err)
 	}
 	findAll(t, tree, objs)
@@ -30,7 +32,7 @@ func testUpsertBuild(t *testing.T, numElem int, m ChildIndex, n ChildIndex) {
 	objs := of.Mproduce(numElem)
 	tree, _ := newTestMemTree(of, m, n)
 	for _, obj := range objs {
-		if err := tree.Upsert(obj, nil); err != nil {
+		if err := tree.Upsert(context.TODO(), obj, nil); err != nil {
 			t.Fatalf("Error in upsert: %v\n", err)
 		}
 	}
@@ -61,7 +63,7 @@ func TestSimpleBuildSmall(t *testing.T) {
 
 func findAll(t *testing.T, tree *Tree, objs []KeyValuePair) {
 	for i, kvp := range objs {
-		v, _, err := tree.Find(kvp.Key)
+		v, _, err := tree.Find(context.TODO(), kvp.Key)
 		if err != nil {
 			t.Fatalf("Find for obj %d yielded an error: %v", i, err)
 		}


### PR DESCRIPTION
So that `mdmerkle` can cancel tree building properly. We are vendoring this package so this shouldn't break anything until we update the vendor.